### PR TITLE
Adapt Code to a Locust Bug, changed pom to jdk 9 and minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@
 locustapitest.iml
 src/main/resources/performance/locust-master.pyc
 src/main/resources/performance/__pycache__/locust-master.*.pyc
+performanceResults_stats_history.csv
+performanceResults_stats.csv
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.demo.locustapitest</groupId>
   <artifactId>locustapitest</artifactId>
   <version>0.0.1-SNAPSHOT</version>
-  <name>locust4j</name>
+  <name>locustapitest</name>
   <description>Load and Performance Test done in BDD Style with Java, Locust4j and Cucumber</description>
   <url>https://github.com/cucumber-locust4j/locustapitest</url>
   
@@ -35,8 +35,6 @@
   
   	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>9</maven.compiler.source>
-		<maven.compiler.target>9</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
   <artifactId>locustapitest</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>locust4j</name>
-  <description>LocustApiTest is a load automation framework test written in java that use cucumber, restassured and locust4j.</description>
-  <url>https://github.com/dmarcas/locustapitest.git</url>
+  <description>Load and Performance Test done in BDD Style with Java, Locust4j and Cucumber</description>
+  <url>https://github.com/cucumber-locust4j/locustapitest</url>
   
   <licenses>
        <license>
@@ -17,7 +17,7 @@
    
    <issueManagement>
        <system>Github Issues</system>
-       <url>https://github.com/dmarcas/locustapitest/issues</url>
+       <url>https://github.com/cucumber-locust4j/locustapitest/issues</url>
    </issueManagement>
    
    <developers>
@@ -35,8 +35,8 @@
   
   	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>9</maven.compiler.source>
+		<maven.compiler.target>9</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -176,35 +176,35 @@
 		</dependency>
 
 	</dependencies>
-	
+
 	<build>
-     <plugins>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-compiler-plugin</artifactId>
-         <version>3.7.0</version>
-         <configuration>
-           <source>1.8</source>
-           <target>1.8</target>
-            <encoding>UTF-8</encoding>          
-         </configuration>
-       </plugin>
-         <plugin>
-             <!-- Build an executable JAR -->
-             <groupId>org.apache.maven.plugins</groupId>
-             <artifactId>maven-jar-plugin</artifactId>
-             <version>3.1.0</version>
-             <configuration>
-                 <archive>
-                     <manifest>
-                         <addClasspath>true</addClasspath>
-                         <classpathPrefix>lib/</classpathPrefix>
-                         <mainClass>com.demo.locustapitest.locustapitest.Main</mainClass>
-                     </manifest>
-                 </archive>
-             </configuration>
-         </plugin>
-       </plugins>
-   </build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>9</source>
+					<target>9</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+			<plugin>
+				<!-- Build an executable JAR -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<classpathPrefix>lib/</classpathPrefix>
+							<mainClass>com.demo.locustapitest.locustapitest.Main</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
   
 </project>

--- a/src/main/java/graph/LocustBarChart.java
+++ b/src/main/java/graph/LocustBarChart.java
@@ -40,10 +40,10 @@ public class LocustBarChart {
      */
 	public void createChart() {
 		this.fileName = "performanceChart"+System.currentTimeMillis()+".png";
-		File file = new File(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getChartPath())+"/"+this.fileName);
-        JFreeChart chart = ChartFactory.createBarChart(TITLE,CATEGORYAXISLABELTITLE,VALUEAXISLABELTITLE, createDataset(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getStatsReportPath())), PlotOrientation.VERTICAL,false,true,false);
+		File file = new File(ConfigReader.getInstance().getChartPath()+"/"+this.fileName);
+        JFreeChart chart = ChartFactory.createBarChart(TITLE,CATEGORYAXISLABELTITLE,VALUEAXISLABELTITLE, createDataset(ConfigReader.getInstance().getStatsReportPath()), PlotOrientation.VERTICAL,false,true,false);
         chart.addSubtitle(0, new TextTitle(" "));
-        chart.addSubtitle(1, new TextTitle(this.createRequestResults(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getStatsReportPath()))));
+        chart.addSubtitle(1, new TextTitle(this.createRequestResults(ConfigReader.getInstance().getStatsReportPath())));
         chart.addSubtitle(2, new TextTitle(" "));
         try {
             ChartUtils.saveChartAsPNG(file, chart, CHARTWIDTH, CHARTHEIGHT);

--- a/src/main/java/helpers/FileOperations.java
+++ b/src/main/java/helpers/FileOperations.java
@@ -94,8 +94,6 @@ public class FileOperations {
 	   try {
 			  FileUtils.deleteDirectory(new File(path));
 			  FileUtils.forceMkdir(new File(path));
-			  //File historyStats = new File(this.getAbsolutePath(ConfigReader.getInstance().getStatsHistoryReportPath()));
-			  //File stats = new File(this.getAbsolutePath(ConfigReader.getInstance().getStatsReportPath()));
 		  } catch (IOException e) {
 			  logger.error("Something went wrong initialising the csv directory");
 		  }		

--- a/src/main/java/helpers/FileOperations.java
+++ b/src/main/java/helpers/FileOperations.java
@@ -94,8 +94,8 @@ public class FileOperations {
 	   try {
 			  FileUtils.deleteDirectory(new File(path));
 			  FileUtils.forceMkdir(new File(path));
-			  File historyStats = new File(this.getAbsolutePath(ConfigReader.getInstance().getStatsHistoryReportPath()));
-			  File stats = new File(this.getAbsolutePath(ConfigReader.getInstance().getStatsReportPath()));
+			  //File historyStats = new File(this.getAbsolutePath(ConfigReader.getInstance().getStatsHistoryReportPath()));
+			  //File stats = new File(this.getAbsolutePath(ConfigReader.getInstance().getStatsReportPath()));
 		  } catch (IOException e) {
 			  logger.error("Something went wrong initialising the csv directory");
 		  }		

--- a/src/main/java/performance/LocustOperations.java
+++ b/src/main/java/performance/LocustOperations.java
@@ -23,8 +23,8 @@ public class LocustOperations {
 	private static final String NAMEOFREPORT = "performanceResults";
 	private static final Logger logger = LoggerFactory.getLogger(LocustOperations.class);
 	private static String masterFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getLocustMasterFilePath());
-    //private static String csvReportFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getCsvReportFolderPath());
     private static String operatingSystem = System.getProperty("os.name").toLowerCase();
+    //private static String csvReportFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getCsvReportFolderPath());
 
 	private String locustTask;
     private String master = "127.0.0.1";
@@ -70,7 +70,6 @@ public class LocustOperations {
 	 * This method raise the master with the parameters of the test defined in cucumber
 	 */
 	public void executeMaster() {
-        //String command="-f "+ masterFilePath +" --master --no-web --csv="+csvReportFilePath +"\\"+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
         String command="-f "+ masterFilePath +" --master --no-web --csv="+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
         if (operatingSystem.indexOf("win") >= 0) {
         	command = "cmd.exe /c start /MIN locust.exe " + command;

--- a/src/main/java/performance/LocustOperations.java
+++ b/src/main/java/performance/LocustOperations.java
@@ -120,15 +120,17 @@ public class LocustOperations {
 		}
 	}
     
-    @SuppressWarnings("resource")
-	public Boolean checkWindowsLocustService() {
+    public Boolean checkWindowsLocustService() {
          try {               	 
         	 Process process = Runtime.getRuntime().exec("tasklist");
         	 Scanner reader = new Scanner(process.getInputStream(), "UTF-8");
         	 while(reader.hasNextLine()) {
-                 if(reader.nextLine().contains("locust"))
+                 if(reader.nextLine().contains("locust")) {
+                	 reader.close();
                      return true;
-         	}             
+                 }
+         	}    
+        	 reader.close(); 
          } catch (IOException error) {
          	logger.error("Something went wrong checking locust service in windows system");
          }

--- a/src/main/java/performance/LocustOperations.java
+++ b/src/main/java/performance/LocustOperations.java
@@ -23,7 +23,7 @@ public class LocustOperations {
 	private static final String NAMEOFREPORT = "performanceResults";
 	private static final Logger logger = LoggerFactory.getLogger(LocustOperations.class);
 	private static String masterFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getLocustMasterFilePath());
-    private static String csvReportFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getCsvReportFolderPath());
+    //private static String csvReportFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getCsvReportFolderPath());
     private static String operatingSystem = System.getProperty("os.name").toLowerCase();
 
 	private String locustTask;
@@ -70,12 +70,10 @@ public class LocustOperations {
 	 * This method raise the master with the parameters of the test defined in cucumber
 	 */
 	public void executeMaster() {
-		System.out.println(csvReportFilePath+"\\"+ NAMEOFREPORT);
         //String command="-f "+ masterFilePath +" --master --no-web --csv="+csvReportFilePath +"\\"+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
         String command="-f "+ masterFilePath +" --master --no-web --csv="+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
         if (operatingSystem.indexOf("win") >= 0) {
         	command = "cmd.exe /c start /MIN locust.exe " + command;
-        	System.out.println(command);
         } else {
         	command= "locust " + command;
         }

--- a/src/main/java/performance/LocustOperations.java
+++ b/src/main/java/performance/LocustOperations.java
@@ -69,12 +69,13 @@ public class LocustOperations {
 	/*
 	 * This method raise the master with the parameters of the test defined in cucumber
 	 */
-    @SuppressWarnings("unused")
 	public void executeMaster() {
-        String command="-f "+ masterFilePath +" --master --no-web --csv="+csvReportFilePath +"/"+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
-
+		System.out.println(csvReportFilePath+"\\"+ NAMEOFREPORT);
+        //String command="-f "+ masterFilePath +" --master --no-web --csv="+csvReportFilePath +"\\"+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
+        String command="-f "+ masterFilePath +" --master --no-web --csv="+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
         if (operatingSystem.indexOf("win") >= 0) {
         	command = "cmd.exe /c start /MIN locust.exe " + command;
+        	System.out.println(command);
         } else {
         	command= "locust " + command;
         }

--- a/src/main/java/performance/LocustOperations.java
+++ b/src/main/java/performance/LocustOperations.java
@@ -22,7 +22,8 @@ public class LocustOperations {
 	private static final String TASKPACKAGEPATH = "locusttask";
 	private static final String NAMEOFREPORT = "performanceResults";
 	private static final Logger logger = LoggerFactory.getLogger(LocustOperations.class);
-	private static String masterFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getLocustMasterFilePath());
+	private static String masterFilePath = ConfigReader.getInstance().getLocustMasterFilePath();
+	private static String csvReportFilePath = ConfigReader.getInstance().getCsvReportFolderPath();
     private static String operatingSystem = System.getProperty("os.name").toLowerCase();
 
 	private String locustTask;
@@ -69,7 +70,7 @@ public class LocustOperations {
 	 * This method raise the master with the parameters of the test defined in cucumber
 	 */
 	public void executeMaster() {
-        String command="-f "+ masterFilePath +" --master --no-web --csv="+ NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
+        String command="-f "+ masterFilePath +" --master --no-web --csv="+ csvReportFilePath + NAMEOFREPORT +" --expect-slaves=1 -c "+ maxUsers +" -r "+ usersLoadPerSecond+" -t"+testTime+"m";
         if (operatingSystem.indexOf("win") >= 0) {
         	command = "cmd.exe /c start /MIN locust.exe " + command;
         } else {
@@ -137,7 +138,7 @@ public class LocustOperations {
     //It returns true or false if the Max response time is higher or not than the expected 
     public Boolean checkMaxResponseTime(DataTable testData) {
     	Boolean higher = false;
-    	List<String[]> data = FileOperations.getInstance().readCSV(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getStatsReportPath()));    	
+    	List<String[]> data = FileOperations.getInstance().readCSV(ConfigReader.getInstance().getStatsReportPath());    	
     	try {
 			if (this.getMaxResponseTime(data, (data.size()-1))>Long.parseLong(AuxiliarMethods.getInstance().getDataTableValue(testData, "Expected Time"))){
 				higher = true;

--- a/src/main/java/performance/LocustOperations.java
+++ b/src/main/java/performance/LocustOperations.java
@@ -24,7 +24,6 @@ public class LocustOperations {
 	private static final Logger logger = LoggerFactory.getLogger(LocustOperations.class);
 	private static String masterFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getLocustMasterFilePath());
     private static String operatingSystem = System.getProperty("os.name").toLowerCase();
-    //private static String csvReportFilePath = FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getCsvReportFolderPath());
 
 	private String locustTask;
     private String master = "127.0.0.1";

--- a/src/main/resources/configs/config.properties
+++ b/src/main/resources/configs/config.properties
@@ -1,5 +1,5 @@
-statsReportLocation=performanceResults_stats.csv
-statsHistoryReportLocation=performanceResults_stats_history.csv
+statsReportLocation=target/csvlocustsresults/performanceResults_stats.csv
+statsHistoryReportLocation=target/csvlocustsresults/performanceResults_stats_history.csv
 chartLocation=target/cucumber-reports/locustcharts/
 locustMasterFile=src/main/resources/performance/locust-master.py
 csvReportFolderLocation=target/csvlocustsresults/

--- a/src/main/resources/configs/config.properties
+++ b/src/main/resources/configs/config.properties
@@ -1,7 +1,5 @@
-statsReportLocation=target/csvlocustsresults/performanceResults_stats.csv
-statsHistoryReportLocation=target/csvlocustsresults/performanceResults_stats_history.csv
-requestsReportLocation=target/csvlocustsresults/performanceResults_requests.csv
-distributionReportLocation=target/csvlocustsresults/performanceResults_distribution.csv
+statsReportLocation=performanceResults_stats.csv
+statsHistoryReportLocation=performanceResults_stats_history.csv
 chartLocation=target/cucumber-reports/locustcharts/
 locustMasterFile=src/main/resources/performance/locust-master.py
 csvReportFolderLocation=target/csvlocustsresults/

--- a/src/test/java/runner/TestRunner.java
+++ b/src/test/java/runner/TestRunner.java
@@ -30,13 +30,13 @@ public class TestRunner {
 		@BeforeClass
 		public static void cleanLocustChartsDirectory() {
 			//Delete and create the locustcharts folder and csv folder in order to ensure that exists in every execution
-			FileOperations.getInstance().folderInitialisation(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getChartPath()), FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getCsvReportFolderPath()));
+			FileOperations.getInstance().folderInitialisation(ConfigReader.getInstance().getChartPath(), ConfigReader.getInstance().getCsvReportFolderPath());
 		}
 
 	    @AfterClass
 	    public static void writeExtentReport() {
 	        try {
-	            Reporter.loadXMLConfig(new File(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getExtentReportConfigPath())));
+	            Reporter.loadXMLConfig(new File(ConfigReader.getInstance().getExtentReportConfigPath()));
 	        } catch (NoSuchMethodError ex){
 	            logger.error("Something went wrong writting in the Extent Report");
 	        }

--- a/src/test/java/steps/Hooks.java
+++ b/src/test/java/steps/Hooks.java
@@ -11,7 +11,6 @@ import cucumber.api.java.Before;
 
 import graph.LocustBarChart;
 import helpers.ConfigReader;
-import helpers.FileOperations;
 
 public class Hooks {
 	
@@ -29,7 +28,7 @@ public class Hooks {
 			//Create the chart after Scenario iteration
 			LocustBarChart locustBarChart = new LocustBarChart();
 			locustBarChart.createChart();
-			File destinationPath = new File(FileOperations.getInstance().getAbsolutePath(ConfigReader.getInstance().getChartPath() + locustBarChart.getFileName()));
+			File destinationPath = new File(ConfigReader.getInstance().getChartPath() + locustBarChart.getFileName());
 			//Add the image to the Report
 			Reporter.addScreenCaptureFromPath(destinationPath.toString(), "Performance Results");
 		}


### PR DESCRIPTION
-Changed the location of the csv report creation. The location of the report is changed due that exist a bug in locust.io. The locust csv creation is inestable when manage absolute paths and sometimes crash (most of the times works right). I reported this by slack, but meantime, it's better to ensure that works right with the default path.
-Changed pom to jdk 9.
-Minor changes.